### PR TITLE
Correct country for JSTalks Bulgaria

### DIFF
--- a/conferences/2017/javascript.json
+++ b/conferences/2017/javascript.json
@@ -1264,7 +1264,7 @@
     "name": "JSTalks Bulgaria",
     "startDate": "2017/11/18",
     "city": "Sofia",
-    "country": "U.S.A.",
+    "country": "Bulgaria",
     "url": "http://www.jstalks.net/"
   },
   {


### PR DESCRIPTION
Was USA, should be Bulgaria.